### PR TITLE
Change RubyGems source to https URL to avoid Bundler warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'webby', '~> 0.9.4'
 gem 'coderay', '~> 0.9.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     RedCloth (4.2.9)
     addressable (2.2.8)


### PR DESCRIPTION
This prevents the warning "The source :rubygems is deprecated because HTTP requests are insecure."
