### PR TITLE
Partialise and fix links for repos

### DIFF
--- a/source/_repos.html.slim
+++ b/source/_repos.html.slim
@@ -1,0 +1,16 @@
+ul
+  li
+    | For bugs with rspec-rails:&nbsp;
+    = link_to 'https://github.com/rspec/rspec-rails', 'https://github.com/rspec/rspec-rails'
+  li
+    | For bugs with rspec-core:&nbsp;
+    = link_to 'https://github.com/rspec/rspec-core', 'https://github.com/rspec/rspec-core'
+    |  (runner, configuration, etc)
+  li
+    | For bugs with rspec-mocks:&nbsp;
+    = link_to 'https://github.com/rspec/rspec-mocks', 'https://github.com/rspec/rspec-mocks'
+    |  (doubles, spies, etc)
+  li
+    | For bugs with rspec-expectations:&nbsp;
+    = link_to 'https://github.com/rspec/rspec-expectations', 'https://github.com/rspec/rspec-expectations'
+    |  (matchers)

--- a/source/contributing.html.slim
+++ b/source/contributing.html.slim
@@ -5,19 +5,4 @@ section
     p
       | If you have an idea to improve RSpec or find a bug, you are encouraged
         to file a pull request or issue with the appropriate repository on Github.
-      ul
-        li
-          | For bugs with rspec-rails:&nbsp;
-          = link_to 'https://github.com/rspec/rspec-rails', 'https://rspec/rspec-rails'
-        li
-          | For bugs with rspec-core:&nbsp;
-          = link_to 'https://github.com/rspec/rspec-core', 'https://rspec/rspec-core'
-          |  (runner, configuration, etc)
-        li
-          | For bugs with rspec-mocks:&nbsp;
-          = link_to 'https://github.com/rspec/rspec-mocks', 'https://rspec/rspec-mocks'
-          |  (doubles, spies, etc)
-        li
-          | For bugs with rspec-expectations:&nbsp;
-          = link_to 'https://github.com/rspec/rspec-expectations', 'https://rspec/rspec-expectations'
-          |  (matchers)
+      = partial "repos"

--- a/source/help.html.slim
+++ b/source/help.html.slim
@@ -28,21 +28,6 @@ section
     p
       | If you encounter a bug in rspec itself you are encouraged to open up
         an issue on the appropriate repository on Github.
-      ul
-        li
-          | For bugs with rspec-rails:&nbsp;
-          = link_to 'https://github.com/rspec/rspec-rails', 'https://rspec/rspec-rails'
-        li
-          | For bugs with rspec-core:&nbsp;
-          = link_to 'https://github.com/rspec/rspec-core', 'https://rspec/rspec-core'
-          |  (runner, configuration, etc)
-        li
-          | For bugs with rspec-mocks:&nbsp;
-          = link_to 'https://github.com/rspec/rspec-mocks', 'https://rspec/rspec-mocks'
-          |  (doubles, spies, etc)
-        li
-          | For bugs with rspec-expectations:&nbsp;
-          = link_to 'https://github.com/rspec/rspec-expectations', 'https://rspec/rspec-expectations'
-          |  (matchers)
+      = partial "repos"
     p
       b Please note we prefer you don't open general support requests on Gitub.


### PR DESCRIPTION
Repo links were broken, plus we use the same set twice so why not partialise them
