### PR TITLE
Remove ruby restriction in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-ruby "2.1.4"
-
 gem "middleman", "~> 3.3.6"
 gem "middleman-livereload", "~> 3.3.4"
 gem "middleman-syntax", :github => "middleman/middleman-syntax"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,24 @@
 rspec-website
 =============
 
-source for rspec.info
+Source for rspec.info.
+
+Requires a recent version of Ruby (2.1.x), bundler and imagemagick (to generate favicons).
+
+## Setup
+
+* `brew install imagemagick`
+* `bundle install`
+* `middleman build`
+
+## Developing
+
+* `middleman server`
+
+## Deploying
+
+* `middleman deploy`
 
 ## To Do:
 
 * [ ] Actually implement the rest of the homepage
-* [ ] Write proper content for:
-  * [ ] About (still needs history)


### PR DESCRIPTION
We don't require the most up to date version of Ruby because it's not a hosted app, but we should clarify we expect a recent version when working on this. I also added some deployment / setup instructions.
