### PR TITLE
Tweak blog headers

### DIFF
--- a/source/layouts/blog_post.slim
+++ b/source/layouts/blog_post.slim
@@ -1,7 +1,7 @@
 = wrap_layout :layout do
   section
     article.blog_post
-      h2 =current_page.data.title
+      h1 =current_page.data.title
       h3.author =current_page.data.author
       = yield
       = partial "disqus"

--- a/source/stylesheets/bitters/_typography.scss
+++ b/source/stylesheets/bitters/_typography.scss
@@ -17,13 +17,12 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 h1 {
-
   font-size: $base-font-size * 2.25; // 16 * 2.25 = 36px
 }
 
 h2 {
   text-align: center;
-  color: #fb5c28;
+  color: $header-text-color;
   font-size: $base-font-size * 3; // 16 * 2 = 32px
 }
 

--- a/source/stylesheets/bitters/_variables.scss
+++ b/source/stylesheets/bitters/_variables.scss
@@ -28,6 +28,7 @@ $base-body-color: #fffcf7;
 //  Font Colors
 $base-font-color: $dark-gray;
 $base-accent-color: $blue;
+$header-text-color: #fb5c28;
 
 //  Text Link Colors
 $base-link-color: $base-accent-color;

--- a/source/stylesheets/pages/blog.css.scss
+++ b/source/stylesheets/pages/blog.css.scss
@@ -26,9 +26,20 @@
     margin-top: -1em;
   }
 
-  section article h2 {
+  section article h1 {
     margin: 1em 0;
     padding: 0;
+  }
+
+  h1 {
+    color: $header-text-color;
+    font-size: 3em;
+    padding: 1em;
+    text-align: center;
+  }
+
+  h2 {
+    font-size: 2em;
   }
 
   h3 {


### PR DESCRIPTION
This changes the main blog article header to a h1 and changes the styles to match the existing h2 styles, then tweaks the h2's to be smaller.

Fixes #47 

![screen shot 2015-02-02 at 10 17 08](https://cloud.githubusercontent.com/assets/162976/5994374/dff82840-aac4-11e4-8aab-e745f8849c0b.png)
