### PR TITLE
Fix minor error in code snippet

### DIFF
--- a/source/blog/2015-02-03-rspec-3-2-has-been-released.md
+++ b/source/blog/2015-02-03-rspec-3-2-has-been-released.md
@@ -65,7 +65,7 @@ RSpec.configure do |config|
 end
 
 # 3. Shared context auto-inclusion: groups tagged with
-#    `:redis` will have this context included.
+#    `:uses_redis` will have this context included.
 RSpec.shared_context "Uses Redis", :uses_redis do
   let(:redis) { Redis.connect(ENV['REDIS_URL']) }
   before { redis.flushdb }


### PR DESCRIPTION
A very minor fix. Align comment and code in snippet to both use `:uses_redis` for the tag name.

Cheers!