### PR TITLE
Remove erroneous comma from asciinema script

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -104,7 +104,7 @@ helpers do
   def asciinema_video(id, speed: 1)
     <<-HTML.gsub(/^ +\|/, '')
       |<div class="asciinema-video">
-      |  <script type="text/javascript" src="https://asciinema.org/a/#{id}.js" id="asciicast-#{id}" data-size="small" data-speed="#{speed}", async></script>
+      |  <script type="text/javascript" src="https://asciinema.org/a/#{id}.js" id="asciicast-#{id}" data-size="small" data-speed="#{speed}" async></script>
       |</div>
     HTML
   end


### PR DESCRIPTION
Extra comma gets parsed by Firefox as attribute name: `... ,="" async`