### PR TITLE
Link to rspec-rails upgrade notes

### DIFF
--- a/source/_upgrade_summary.html.md
+++ b/source/_upgrade_summary.html.md
@@ -7,3 +7,7 @@ detailed upgrade checklist tailored to your project.
 
 In addition, [Yuji Nakayama](https://twitter.com/nkym37) has created [Transpec](http://yujinakayama.me/transpec/) -- an absolutely amazing tool that can
 automatically upgrade most RSpec suites. We've tried it on a few projects and have been _amazed_ at how well it works.
+
+If you use `rspec-rails` you might want to read the
+[upgrade notes](https://relishapp.com/rspec/rspec-rails/docs/upgrade)
+specific to that gem.


### PR DESCRIPTION
A recent rspec-rails issue (rspec/rspec-rails#1415) made me realise we don't mention anywhere on the RSpec site about rails specific issues, I toyed with the idea of making a rails specific upgrade page but I think it might end up out of sync very easily, so for now I'm just adding a link to the relish app docs.

<img width="913" alt="screen shot 2015-07-09 at 10 40 12" src="https://cloud.githubusercontent.com/assets/162976/8585569/ed58ef78-2626-11e5-88c4-632b71cf369d.png">