### PR TITLE
Use redcarpet as a Markdown renderer instead of kramdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,3 +16,5 @@ gem "builder", "~> 3.0"
 
 # For HTML-aware blog post summaries.
 gem 'nokogiri'
+
+gem 'redcarpet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,7 @@ GEM
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
+    redcarpet (3.3.4)
     rouge (1.8.0)
     sass (3.4.13)
     slim (3.0.3)
@@ -174,4 +175,8 @@ DEPENDENCIES
   middleman-syntax!
   neat
   nokogiri
+  redcarpet
   slim
+
+BUNDLED WITH
+   1.11.2

--- a/config.rb
+++ b/config.rb
@@ -48,7 +48,15 @@ page "/**/feed.xml", layout: false
 
 # for build
 activate :syntax
-set :markdown_engine, :kramdown
+
+set :markdown_engine, :redcarpet
+set :markdown, autolink: true,
+               fenced_code_blocks: true,
+               no_intra_emphasis: true,
+               smartypants: true,
+               strikethrough: true,
+               tables: true
+
 activate :directory_indexes
 
 page "documentation/**/*.html", directory_index: false


### PR DESCRIPTION
for more compatibility with GitHub flavored Markdown.

This should fix https://github.com/rspec/rspec.github.io/pull/92#issuecomment-180912560.