### PR TITLE
Fix typo in link

### DIFF
--- a/source/contributing.html.slim
+++ b/source/contributing.html.slim
@@ -12,6 +12,6 @@ section
       | See&nbsp;
       = link_to 'rspec-dev', 'https://github.com/rspec/rspec-dev'
       |  for how to develop on and test RSpec, as well as any&nbsp;
-      = link_to 'DEV-README.md', '(https://github.com/rspec/rspec-core/blob/master/DEV-README.md'
+      = link_to 'DEV-README.md', 'https://github.com/rspec/rspec-core/blob/master/DEV-README.md'
       |  that may be in that repository.
       = partial "repos"


### PR DESCRIPTION
This PR fixes a typo in the link to `DEV_README.md` on the Contributing page.