### PR TITLE
Change RSpec Book link to Amazon

### DIFF
--- a/source/index.slim
+++ b/source/index.slim
@@ -51,7 +51,7 @@ section.get-started
       h2 The RSpec Book
       p
         | The RSpec Book will introduce you to RSpec, Cucumber, and a number of other tools that make up the Ruby BDD family. Replete with tutorials and practical examples, the RSpec Book will help you get your BDD on, taking you from executable requirements to working software that is clean, well tested, well documented, flexible and highly maintainable.
-      = link_to "Check out the book", "http://pragprog.com/book/achbd/the-rspec-book", target: '_blank'
+      = link_to "Check out the book", "http://www.amazon.com/RSpec-Book-Behaviour-Development-Cucumber/dp/1934356379", target: '_blank'
 
   p
 


### PR DESCRIPTION
The PragProg no longer has a link to purchase The RSpec Book, saying it's out of print (even the e-book). Amazon still has copies available for purchase, so that seems like a better link for now.