### PR TITLE
Documentation: fix overlapping version menus

### DIFF
--- a/source/stylesheets/pages/documentation.css.scss
+++ b/source/stylesheets/pages/documentation.css.scss
@@ -16,6 +16,7 @@
   > a {
     @extend %border-box;
     padding: 4px 10px;
+    z-index: 1;
   }
 
   > ul {
@@ -25,6 +26,7 @@
     padding: 0 10px;
     position: absolute;
     top: -18px;
+    z-index: 2;
   }
 
   &:hover {


### PR DESCRIPTION
An expanded version list shows on top of the next link
Currently is show under it, causing a funny "wrong menu entry" effect
(the second 3.8 menu is shown on top of the 3.4 link from the first 3.8
menu)