### PR TITLE
Fix irc channel formatting

### DIFF
--- a/source/help.html.slim
+++ b/source/help.html.slim
@@ -21,7 +21,7 @@ section
 
     h4 IRC
     p
-      | If you prefer, you can join the `#rspec` channel on freenode, there are
+      | If you prefer, you can join the <pre>#rspec</pre> channel on freenode, there are
         often people willing to help hanging around, although the core team do
         not monitor this continuously they are often around to help out.
 


### PR DESCRIPTION
On the website it looks like backticks were intended for preformatted text/code, as with markdown, but they are just rendered verbatim:

![Screenshot_2019-10-10 Getting help with RSpec](https://user-images.githubusercontent.com/1710874/66608058-69775600-eb6a-11e9-92f9-7646b8779d1d.png)

Assuming that is the case, I've changed the backticks to pre tags so that it should render the irc channel name more clearly.