### PR TITLE
Remove push by hand instructions for staging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,7 @@ this environment here: https://hub.docker.com/r/2performantirina/middleman-and-i
 
 Run `bundle exec middleman build`, which will compile the site to `docs`.
 
-To deploy to staging you can create a PR against https://github.com/RSpec-Staging/rspec-staging.github.io/
-or you can push temporarily with:
-
-```
-# Deploy your branch to source on staging
-git push staging <branch>:source --force
-# or if you have your branch checked out
-git push staging HEAD:source --force
-```
+To deploy to staging you can create a PR against https://github.com/RSpec-Staging/rspec-staging.github.io/.
 
 To deploy to production you should create a PR against https://github.com/rspec/rspec.github.io/.
 


### PR DESCRIPTION
@pirj I'm removing the push by hand instructions for staging, you need to remove the `CNAME` file for this to happen and I'd rather not risk it.