### PR TITLE
Fix typos and formatting on help page

### DIFF
--- a/source/help.html.slim
+++ b/source/help.html.slim
@@ -7,7 +7,7 @@ section
 
     h4 Mailing List
     p
-      | For general support and development enquirines we recomment joining
+      | For general support and development enquiries we recommend joining
         the rspec mailing list / google group. There are many experienced
         rspec developers on this list who are normally only to happy to help
         solve your development woes.

--- a/source/help.html.slim
+++ b/source/help.html.slim
@@ -21,7 +21,7 @@ section
 
     h4 IRC
     p
-      | If you prefer, you can join the <pre>#rspec</pre> channel on freenode, there are
+      | If you prefer, you can join the <code>#rspec</code> channel on freenode, there are
         often people willing to help hanging around, although the core team do
         not monitor this continuously they are often around to help out.
 


### PR DESCRIPTION
## Fix typos on help page

Fix two types on the help page:

- enquirines -> enquiries
- recomment -> recommend

## Fix formatting of #rspec IRC channel name

On the help page the #rspec IRC channel name is listed. Using the `pre`
tag element it would show the channel name on a new line in the middle
of the sentence, using a dark background with dark text, making it
difficult to read.

Instead use the `code` tag element to show the channel name inline in
a monospaced font for it to stand out in the sentence.

Screenshot, before on the left, this PR on the right:

<img width="1657" alt="image" src="https://user-images.githubusercontent.com/282402/106352211-5baa8e80-62e1-11eb-8ba1-988b2e78e0e9.png">
