### PR TITLE
Add local Docker environment for dev and build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@
 .DS_Store
 
 # Ignore bundler artifacts
-bin
 bundle
 
 # These ignore the yard generated css/js as we have a version
@@ -44,3 +43,5 @@ source/documentation/3.6/**/css
 source/documentation/3.6/**/js
 source/documentation/3.7/**/css
 source/documentation/3.7/**/js
+
+tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ruby:2.7
+
+RUN apt update && apt upgrade -y && apt install imagemagick nodejs -y
+
+RUN gem update --system
+RUN gem install bundler --version 1.17.3
+
+# Helper scripts
+COPY bin/container_boot.sh /container_boot.sh
+COPY bin/container_build.sh /container_build.sh
+RUN chmod +x /container_boot.sh /container_build.sh
+
+EXPOSE 4567
+
+WORKDIR /app
+# Store bundle inside tmp dir in project so the bundle is reused between builds
+ENV BUNDLE_PATH=/app/tmp/docker/bundle
+
+CMD /container_boot.sh

--- a/README.md
+++ b/README.md
@@ -17,9 +17,21 @@ Run `LIVERELOAD=true middleman server`
 
 ## Docker Setup + Development
 
-If you don't have a local Ruby environment suitable to making changes to rspec.info,
-or prefer containerised development; you can find a 3rd party Docker image setup for
-this environment here: https://hub.docker.com/r/2performantirina/middleman-and-imagemagick
+If you don't have a local Ruby environment suitable to making changes to
+rspec.info, or prefer containerised development; use the following scripts to
+build the included Docker image and build the site in the containerised
+environment instead.
+
+```
+# Start the middleman server. Access site at http://localhost:4567
+bin/server
+
+# Build the site in the `docs/` directory. Replacement for `middleman build`.
+bin/build
+
+# Start a console inside the docker container. Useful for debugging or running commands locally.
+bin/console
+```
 
 ## Deploying
 

--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Build the middleman site in the Docker container.
+
+set -eu
+
+bin/container_build
+docker run -it --rm --volume "$(pwd):/app" rspec-middleman:latest /container_build.sh

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Start a shell in the Docker container.
+# Useful for debugging.
+
+set -eu
+
+bin/container_build
+docker run -it --rm --volume "$(pwd):/app" --publish 4567:4567 rspec-middleman:latest sh

--- a/bin/container_boot.sh
+++ b/bin/container_boot.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Private command used by the Docker image to start the middleman server.
+
+bundle install
+bundle exec middleman

--- a/bin/container_build
+++ b/bin/container_build
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Internal command to build the Docker container before every command that needs
+# the Docker container.
+
+set -eu
+
+docker build -t rspec-middleman:latest .

--- a/bin/container_build.sh
+++ b/bin/container_build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Private command used by the Docker image to build the middleman site.
+
+set -eu
+
+bundle install
+bundle exec middleman build --verbose

--- a/bin/server
+++ b/bin/server
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Start the middleman server in the Docker container.
+# Access the server at http://localhost:4567
+
+set -eu
+
+bin/container_build
+docker run -it --rm --volume "$(pwd):/app" --publish 4567:4567 rspec-middleman:latest


### PR DESCRIPTION
To make it easier to set up the local build environment, include a
Docker setup.

I've added a Dockerfile that sets up the container.
The scripts in `bin/` will handle running all the commands in the
container.

I used this setup to test the upgrade in PR #163 