### PR TITLE
Update execjs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ GEM
       http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
     eventmachine (1.2.7)
-    execjs (2.7.0)
+    execjs (2.8.1)
     fast_blank (1.0.0)
     fastimage (2.2.1)
     favicon_maker (1.3.1)


### PR DESCRIPTION
Otherwise, execjs can't find JavaScriptCore on newer macOS

    ruby-2.7.5@rspec-doc/gems/execjs-2.7.0/lib/execjs/runtimes.rb:58:in `autodetect': Could not find a JavaScript runtime. See https://github.com/rails/execjs for a list of available runtimes. (ExecJS::RuntimeUnavailable)

See https://github.com/rails/execjs/commit/1dce3d077866c01d32230aead7b82d7e5b7a341b