### PR TITLE
Fix link to RSpec 3 book on home page

### DIFF
--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -52,7 +52,7 @@ section.get-started
       h3 Effective Testing with RSpec 3: Build Ruby Apps with Confidence
       p
         | This definitive guide from RSpec’s lead developer shows you how to use RSpec to drive more maintainable designs, specify and document expected behavior, and prevent regressions during refactoring. Build a project using RSpec to design, describe, and test the behavior of your code-whether you’re new to testing tools or an experienced developer.
-      = link_to "New book now available!", "https://pragprog.com/book/rspec3/effective-testing-with-rspec-3", target: '_blank'
+      = link_to "New book now available!", "https://pragprog.com/titles/rspec3/effective-testing-with-rspec-3/", target: '_blank'
 
   p
 


### PR DESCRIPTION
The old link wasn’t exactly broken, but the new link takes you straight to the book page rather than a list of search results.

There are various other occurrences of the old link on the blog, but perhaps those should remain that way for Historical Accuracy Purposes.