### PR TITLE
Fix Relish's links

### DIFF
--- a/source/documentation.html.slim
+++ b/source/documentation.html.slim
@@ -53,4 +53,19 @@ section
         Cucumber to ensure they are always up-to-date with the current code base.
 
     ul
-      li= link_to 'http://relishapp.com/rspec', 'http://relishapp.com/rspec'
+      li
+        b
+          | rspec-core:&nbsp;
+        = link_to 'https://relishapp.com/rspec/rspec-core/docs', 'https://relishapp.com/rspec/rspec-core/docs'
+      li
+        b
+          | rspec-expectations:&nbsp;
+        = link_to 'https://relishapp.com/rspec/rspec-expectations/docs', 'https://relishapp.com/rspec/rspec-expectations/docs'
+      li
+        b
+          | rspec-mocks:&nbsp;
+        = link_to 'https://relishapp.com/rspec/rspec-mocks/docs', 'https://relishapp.com/rspec/rspec-mocks/docs'
+      li
+        b
+          | rspec-rails:&nbsp;
+        = link_to 'https://relishapp.com/rspec/rspec-rails/docs', 'https://relishapp.com/rspec/rspec-rails/docs'


### PR DESCRIPTION
The link to Relish is broken.

https://rspec.info/documentation/

This PR adds the following links because Relish does not have RSpec page.

- rspec-core
- rspec-expectations
- rspec-mocks
- rspec-rails
