### PR TITLE
Update README to reflect Javascript Runtime Requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Requires a recent version of Ruby (tested on 2.7.5, Ruby 3.x is not yet working)
 ## Local Setup
 
 * `brew install imagemagick` (or your package manager of choice).
+* `brew install nodejs` (or your javascript runtime of choice for [execjs](https://github.com/rails/execjs)).
 * `bundle install`
 * `middleman build`
 


### PR DESCRIPTION
This is a super small change, just adding a line about needing a Javascript runtime environment such as Node.js for execjs to the README. The need for the package is evident if someone reads the Dockerfile, but the README currently just calls out the need for imagemagick. I also added a link to the execjs page which lists all the possible runtimes, in case someone isn't a fan of Node.