### PR TITLE
Fix use of deprecated method (that breaks middleman build on Ruby 3.2)

### DIFF
--- a/lib/rspec_info/features.rb
+++ b/lib/rspec_info/features.rb
@@ -44,7 +44,7 @@ module RSpecInfo
         if Hash === yaml_section
           yaml_section.each do |heading, contents|
             yaml_path = File.join(FEATURES_DIR, version, library, heading)
-            if Dir.exists?(yaml_path)
+            if Dir.exist?(yaml_path)
 
               # Add missing directory contents
               Dir[File.join(yaml_path, '*')].each do |filename|

--- a/lib/rspec_info/versions.rb
+++ b/lib/rspec_info/versions.rb
@@ -31,7 +31,7 @@ module RSpecInfo
     end
 
     def directories(folder)
-      Dir[File.join(folder, '*')].select { |dir| Dir.exists?(dir) }
+      Dir[File.join(folder, '*')].select { |dir| Dir.exist?(dir) }
     end
   end
 end


### PR DESCRIPTION
Dir.exist? is removed in Ruby 3.2
