### PR TITLE
fix typo in mailer spec documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Requires a recent version of Ruby (tested on 2.7.5, Ruby 3.x is not yet working)
 * `brew install imagemagick` (or your package manager of choice).
 * `brew install nodejs` (or your javascript runtime of choice for [execjs](https://github.com/rails/execjs)).
 * `bundle install`
-* `middleman build`
+* `bundle exec middleman build`
 
 ## Local Developing
 
-Run `LIVERELOAD=true middleman server`
+Run `LIVERELOAD=true bundle exec middleman server`
 
 ## Docker Setup + Development
 

--- a/source/features/6-0/rspec-rails/mailer-specs/index.html.md
+++ b/source/features/6-0/rspec-rails/mailer-specs/index.html.md
@@ -2,7 +2,7 @@
 layout: "feature_index"
 ---
 
-# Mailer sepcs
+# Mailer specs
 
 By default Mailer specs reside in the `spec/mailers` folder. Adding the metadata
 `type: :mailer` to any context makes its examples be treated as mailer specs.

--- a/source/features/6-1/rspec-rails/mailer-specs/index.html.md
+++ b/source/features/6-1/rspec-rails/mailer-specs/index.html.md
@@ -2,7 +2,7 @@
 layout: "feature_index"
 ---
 
-# Mailer sepcs
+# Mailer specs
 
 By default Mailer specs reside in the `spec/mailers` folder. Adding the metadata
 `type: :mailer` to any context makes its examples be treated as mailer specs.


### PR DESCRIPTION
This PR fixes a typo on the mailer specs page, where it has "sepcs" instead of "specs". Current page looks like this:

<img width="957" alt="Screenshot 2024-03-25 at 1 27 46 PM" src="https://github.com/rspec/rspec.github.io/assets/5168781/34e1c9cb-12e6-40aa-b370-ee2515337289">

I've fixed the typo in the two files in which I found it.

I also updated the readme to use `bundle exec middleman build`, since it otherwise fails if the user doesn't have middleman installed globally. Let me know if this is undesired and I'll undo.

I've noticed the same typo in the [main rspec-rails repo](https://github.com/rspec/rspec-rails/blob/967a54d0669d2378d3502b2df06b25c824419d5d/features/mailer_specs/README.md) too. Should that be fixed as well, or does this repo supersede it?