### PR TITLE
fix: cucumber link on documentation page

### DIFF
--- a/source/documentation.html.slim
+++ b/source/documentation.html.slim
@@ -33,7 +33,7 @@ section
 
     p
       | RSpec is composed of multiple libraries, which are designed to work together, or
-        can be used independently with other testing tools like #{link_to 'Cucumber', 'http://cukes.info/'}
+        can be used independently with other testing tools like #{link_to 'Cucumber', 'https://cucumber.io/docs/cucumber/'}
         or #{link_to 'Minitest', 'http://docs.seattlerb.org/minitest/'}. <br/>The parts of RSpec are:
 
     ul


### PR DESCRIPTION
this fix the issue #200 
Change the link of cucumber on doc page