### PR TITLE
Fixed mistype in word "specs"

### DIFF
--- a/source/features/6-0/rspec-rails/mailer-specs/index.html.md
+++ b/source/features/6-0/rspec-rails/mailer-specs/index.html.md
@@ -2,7 +2,7 @@
 layout: "feature_index"
 ---
 
-# Mailer sepcs
+# Mailer specs
 
 By default Mailer specs reside in the `spec/mailers` folder. Adding the metadata
 `type: :mailer` to any context makes its examples be treated as mailer specs.

--- a/source/features/6-1/rspec-rails/mailer-specs/index.html.md
+++ b/source/features/6-1/rspec-rails/mailer-specs/index.html.md
@@ -2,7 +2,7 @@
 layout: "feature_index"
 ---
 
-# Mailer sepcs
+# Mailer specs
 
 By default Mailer specs reside in the `spec/mailers` folder. Adding the metadata
 `type: :mailer` to any context makes its examples be treated as mailer specs.


### PR DESCRIPTION
Word "specs" had a mistype in two files.